### PR TITLE
DEVOPS-3520: add check_if_write_query method for rails 8.1 compatibility

### DIFF
--- a/lib/active_record/connection_adapters/redshift_8_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_8_1_adapter.rb
@@ -360,6 +360,12 @@ module ActiveRecord
         end
       end
 
+      def check_if_write_query(sql)
+        return unless preventing_writes? && write_query?(sql)
+
+        raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
+      end
+
       class << self
         def initialize_type_map(m)
           # :nodoc:


### PR DESCRIPTION
This method is needed for Rails 8.1 compatibility.